### PR TITLE
Bugfix - Avoid invoking the catalyst before available

### DIFF
--- a/android/src/main/java/com/walmartreact/ReactOrientationListener/ReactOrientationListenerModule.java
+++ b/android/src/main/java/com/walmartreact/ReactOrientationListener/ReactOrientationListenerModule.java
@@ -42,9 +42,11 @@ public class ReactOrientationListenerModule extends ReactContextBaseJavaModule {
         }
         params.putString("orientation", orientationValue);
         params.putString("device", getDeviceName());
-        thisContext
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit("orientationDidChange", params);
+        if (thisContext.hasActiveCatalystInstance()) {
+          thisContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit("orientationDidChange", params);
+        }
       }
     };
 


### PR DESCRIPTION
This verifies the catalyst exists and is active before attempting to access it

Fixes https://github.com/walmartreact/react-native-orientation-listener/issues/8
