### PR TITLE
Change param name to match usage. Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ componentDidMount(){
 
 ####addListener(callback)
 
-This method will add a listener that will call the callback anytime the device orienatation changes:
+This method will add a listener that will call the callback anytime the device orientation changes:
 
 ```javascript
-_setOrientation(data) {
+_setOrientation(evt) {
   this.setState({
     orientation: evt.orientation,
     device: evt.device


### PR DESCRIPTION
Renamed the `_setOrientation(data)` param to `evt` to match the usage of `evt`. Fixed typo on _orientation_.
